### PR TITLE
fix: Correct calculation of total price in src/formatter.py

### DIFF
--- a/src/formatter.py
+++ b/src/formatter.py
@@ -28,7 +28,7 @@ def clean_data(df: pd.DataFrame) -> pd.DataFrame:
     df['unit_price'].fillna(0, inplace=True)
 
     # Calculate total price (BUG: uses addition instead of multiplication)
-    df['total_price'] = df['quantity'] + df['unit_price']
+    df['total_price'] = df['quantity'] * df['unit_price']
 
     return df
 


### PR DESCRIPTION
## What does this PR do?
This pull request fixes a calculation error in the `src/formatter.py` file where the `total_price` field was incorrectly computed.

## Changes
- **src/formatter.py**  
  - Fixed `total_price` calculation from using addition (`+`) to multiplication (`*`):

    ```python
    # Before
    df['total_price'] = df['quantity'] + df['unit_price']

    # After
    df['total_price'] = df['quantity'] * df['unit_price']
    ```

## Why is this change needed?
The previous implementation added `quantity` and `unit_price` instead of multiplying them, resulting in incorrect total price values.  
This fix ensures accurate computation of `total_price` across all records.