### PR TITLE
fix: Use better imputing approach

### DIFF
--- a/src/formatter.py
+++ b/src/formatter.py
@@ -25,7 +25,7 @@ def clean_data(df: pd.DataFrame) -> pd.DataFrame:
     df['unit_price'] = pd.to_numeric(df['unit_price'], errors='coerce')
 
     # Impute missing unit_price with 0 (BUG)
-    df['unit_price'].fillna(0, inplace=True)
+    df['unit_price'].fillna(df['unit_price'].mean(), inplace=True)
 
     # Calculate total price (BUG: uses addition instead of multiplication)
     df['total_price'] = df['quantity'] + df['unit_price']


### PR DESCRIPTION
## What does this PR do?
This pull request improves the handling of missing values in the `unit_price` column by replacing them with the column's mean instead of a hardcoded `0`.  

CLOSES  #4 

## Changes
- **src/formatter.py**  
  - Updated `fillna()` logic for `unit_price` to use the column mean:

    ```python
    # Before
    df['unit_price'].fillna(0, inplace=True)

    # After
    df['unit_price'].fillna(df['unit_price'].mean(), inplace=True)
    ```

## Why is this change needed?
Previously, missing `unit_price` values were replaced with `0`, which could skew calculations such as `total_price` and lead to inaccurate results.  
By using the mean value instead, this update provides a more statistically sound approach for imputing missing data and improves data quality for downstream computations.
